### PR TITLE
script.nsi: update project webpage url

### DIFF
--- a/installer/script.nsi
+++ b/installer/script.nsi
@@ -7,8 +7,8 @@
 !define PRODUCT_VERSION "${VERSION}"
 !define PRODUCT_NAME "Gpick"
 !define PRODUCT_NAME_SMALL "gpick"
-!define PRODUCT_PUBLISHER "Albertas Vyðniauskas"
-!define PRODUCT_WEB_SITE "http://code.google.com/p/gpick/"
+!define PRODUCT_PUBLISHER "Albertas VyÃ°niauskas"
+!define PRODUCT_WEB_SITE "http://www.gpick.org/"
 
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 !define PRODUCT_UNINST_ROOT_KEY "HKLM"


### PR DESCRIPTION
I don't suppose this change also updates the metadata for other systems -- e.g. I installed it from the Gnome Shell on Ubuntu, and the website in the about window also shows the Google Code URL:

![screenshot from 2018-03-21 17-45-54](https://user-images.githubusercontent.com/478237/37727598-2adc985a-2d30-11e8-8525-acf66b118abc.png)

I couldn't find any other references to that URL in this repo other than this `script.nsi` file, though, so I'm mentioning this here in case it needs to be changed elsewhere.