### PR TITLE
Fix build failure due to lack of expat and rt libraries

### DIFF
--- a/source/SConscript
+++ b/source/SConscript
@@ -47,12 +47,10 @@ if local_env['BUILD_TARGET'] == 'win32':
 	else:
 		local_env.Append(LINKFLAGS = ['/SUBSYSTEM:WINDOWS', '/ENTRY:mainCRTStartup'], CPPDEFINES = ['XML_STATIC'])
 	objects += SConscript(['winres/SConscript'], exports='env')
-elif local_env['BUILD_TARGET'].startswith('linux'):
-	local_env.Append(LIBS=['rt', 'expat'])
-elif local_env['BUILD_TARGET'].startswith('gnu0'):
-	local_env.Append(LIBS=['rt', 'expat'])
-elif local_env['BUILD_TARGET'].startswith('gnukfreebsd'):
-	local_env.Append(LIBS=['rt', 'expat'])
+else:
+	local_env.Append(LIBS=['expat'])
+	if local_env['BUILD_TARGET'].startswith('linux') or local_env['BUILD_TARGET'].startswith('gnu0') or local_env['BUILD_TARGET'].startswith('gnukfreebsd'):
+		local_env.Append(LIBS=['rt'])
 
 local_env.Append(CPPPATH=['#source'])
 

--- a/source/SConscript
+++ b/source/SConscript
@@ -47,7 +47,7 @@ if local_env['BUILD_TARGET'] == 'win32':
 	else:
 		local_env.Append(LINKFLAGS = ['/SUBSYSTEM:WINDOWS', '/ENTRY:mainCRTStartup'], CPPDEFINES = ['XML_STATIC'])
 	objects += SConscript(['winres/SConscript'], exports='env')
-elif local_env['BUILD_TARGET'] == 'linux2':
+elif local_env['BUILD_TARGET'].startswith('linux'):
 	local_env.Append(LIBS=['rt', 'expat'])
 elif local_env['BUILD_TARGET'].startswith('gnu0'):
 	local_env.Append(LIBS=['rt', 'expat'])


### PR DESCRIPTION
This PR fixes a known build failure on macOS (and presumably on other non-GNU UNIX systems) due to the lack of a flag to use the expat library. See #112.

It also fixes a similar build failure I presume would occur on some systems running Linux kernel 3 or later (depending on the version and distro patching of Python -- see 
https://bugs.python.org/issue12326), though I don't use Linux so I can't verify that.