### PR TITLE
fix broken BOOST_OS_LINUX guard block

### DIFF
--- a/source/Paths.cpp
+++ b/source/Paths.cpp
@@ -29,7 +29,7 @@ struct PathException : std::runtime_error {
 		std::runtime_error(message) {
 	}
 };
-#ifdef BOOST_OS_LINUX
+#if BOOST_OS_LINUX
 static std::string getExecutablePath() {
 	std::vector<char> buffer;
 	buffer.resize(4096);


### PR DESCRIPTION
The "BOOST_OS_LINUX" preprocessor guard block in Paths.cpp is broken, which leads to build errors on Windows (#184).

According to the boost-predef docs https://www.boost.org/doc/libs/1_66_0/doc/html/predef.html 

>  Version numbers that are always defined so that one doesn't have to guard with #ifdef. 

Therefore, the `#ifdef` check passes even if the OS is not Linux.
These macros should be checked using `#if` directives.