### PR TITLE
Fix write of std::vector<bool>::reference

### DIFF
--- a/source/dynv/Xml.cpp
+++ b/source/dynv/Xml.cpp
@@ -113,7 +113,7 @@ struct SerializeVisitor {
 				if (!writeStart(stream, "li"s, true))
 					return false;
 				++indentation;
-				if (!types::xml::write(stream, i, indentation))
+				if (!types::xml::write(stream, T(i), indentation))
 					return false;
 				--indentation;
 				if (!writeIndentation(stream, indentation))
@@ -123,7 +123,7 @@ struct SerializeVisitor {
 			} else {
 				if (!writeStart(stream, "li"s))
 					return false;
-				if (!types::xml::write(stream, i))
+				if (!types::xml::write(stream, T(i)))
 					return false;
 				if (!writeEnd(stream, "li"s))
 					return false;


### PR DESCRIPTION
In `for (const auto &i: std::vector<bool>) {`, `i` is proxy for bool and not a bool. See https://en.cppreference.com/w/cpp/container/vector_bool/reference