### PR TITLE
Add missing include

### DIFF
--- a/source/dynv/Types.cpp
+++ b/source/dynv/Types.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <istream>
 #include <boost/endian/conversion.hpp>
+#include <boost/version.hpp>
 namespace dynv {
 namespace xml {
 bool serialize(std::ostream &stream, const Map &map, bool addRootElement = true, size_t indentationLevel = 1);


### PR DESCRIPTION
`BOOST_VERSION` is only set when `boost/version.hpp` is included.

Closes #226